### PR TITLE
adding JSUT while not yet start training

### DIFF
--- a/TTS-systems/data_config/JSUT/config.yaml
+++ b/TTS-systems/data_config/JSUT/config.yaml
@@ -1,0 +1,11 @@
+name: "JSUT"
+lang_id: "jp"
+
+data_dir: "preprocessed_data/JSUT"
+
+# subsets:
+#     train: "train.txt"
+#     val: "val.txt"
+#     test: "test.txt"
+
+text_cleaners: ["transliteration_cleaners"]


### PR DESCRIPTION
workfile looks like 

- ML_Projeccts                                          
    - TTS-systems                                        
          - preprocessed_data                       
- speech_dataset
    - LJSpeech-1.1
    - jsut_ver1.1 

already finished ...
        Generate JSUT textgrid(python -m scripts.jsut_hts2textgrid).
        Preprocess (Dataset tags in Parsers/__init__.py)
        Clean & split dataset.
        Collect phoneme set (python -m scripts.collect_phonemes) and register them to text/define.py.
        Create data config yaml file and train(single speaker).

waiting for being done …
        In data_config/JSUT, do I need train.txt, val.txt, test.txt, and clean.json ??? 
        Write a script to inference.
